### PR TITLE
[allowed] Allow Nemo D-Bus QML Plugin (API version 2.0)

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -20,5 +20,8 @@ QtMultimedia 5.0
 QtWebKit 3.0
 QtSensors 5.0
 
+# Nemo QML Plugins
+org.nemomobile.dbus 2.0
+
 # ContextKit
 org.freedesktop.contextkit 1.0

--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -54,6 +54,9 @@ qt5-qtdeclarative-import-particles2
 qt5-qtdeclarative-qtquickparticles
 qt5-qtsvg
 
+# Nemo QML Plugins
+nemo-qml-plugin-dbus-qt5
+
 # Qt Modules
 qt5-qtfeedback
 qt5-qtmultimedia


### PR DESCRIPTION
With version 2.0 of the QML import, we have reviewed and stabilized the API:
https://github.com/nemomobile/nemo-qml-plugin-dbus/pull/21

Do not merge yet, will have to wait for the pull request above to be merged and tagged. Also, this is only available from a given (future) SFOS release version, as old versions do not have the 2.0 API import.