### PR TITLE
allow qt5-qtdeclarative-import-sensors

### DIFF
--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -55,6 +55,7 @@ qt5-qtdeclarative-qtquickparticles
 qt5-qtsvg
 qt5-qtgraphicaleffects
 qt5-qtdeclarative-import-positioning
+qt5-qtdeclarative-import-sensors
 
 # Qt Modules
 qt5-qtmultimedia


### PR DESCRIPTION
We allow QtSensors 5.0 QML import since the beginning, so we should also
allow the rpm providing it.