### PR TITLE
Allow libexpat.so.1 please

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -48,6 +48,7 @@ libcrypto.so.10
 liblzma.so.5
 libxml2.so.2
 libbz2.so.1
+libexpat.so.1
 
 # GLib
 libgio-2.0.so.0

--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -76,6 +76,7 @@ libssl.so.10
 libssl.so.10(libssl.so.10)
 liblzma.so.5
 libbz2.so.1
+libexpat.so.1
 
 # Python support
 pyotherside-qml-plugin-python3-qt5


### PR DESCRIPTION
Very stable API. And I'll probably need it fairly soon for one of my apps.