### PR TITLE
Allow libudev.so.1 please

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -49,6 +49,7 @@ liblzma.so.5
 libxml2.so.2
 libbz2.so.1
 libexpat.so.1
+libudev.so.1
 
 # GLib
 libgio-2.0.so.0

--- a/allowed_requires.conf
+++ b/allowed_requires.conf
@@ -77,6 +77,8 @@ libssl.so.10(libssl.so.10)
 liblzma.so.5
 libbz2.so.1
 libexpat.so.1
+libudev.so.1  
+libudev.so.1(LIBUDEV_183)
 
 # Python support
 pyotherside-qml-plugin-python3-qt5


### PR DESCRIPTION
Useful API for detecting SD-Card insertion/removal, e.g. on tablet. Already installed on the device. Last ABI break in 2009: http://upstream-tracker.org/versions/libudev.html