### PR TITLE
Jb31466

### DIFF
--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -482,7 +482,7 @@ validatedesktopfile() {
             # Assume that developers who write QML-only applications with the launcher also use
             # Silica components, and they have to use the silica-qt5 booster to start it up
             validation_error $DESKTOP_NAME "X-Nemo-Application-Type must be silica-qt5 for sailfish-qml apps"
-            validation_info $DESKTOP_NAME "Please see our FAQ here: https://harbour.jolla.com/faq#.desktop-Files"
+            INFO_MSG_PRINTED=1
         else
             $EGREP "^X-Nemo-Application-Type=(no-invoker|generic|qtquick2|qt5)[[:space:]]*$" $DESKTOP_NAME >/dev/null 2>&1
             if [[ $? -ne 0 ]] ; then

--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -475,7 +475,9 @@ validatedesktopfile() {
     $GREP "^X-Nemo-Application-Type=silica-qt5[[:space:]]*$" $DESKTOP_NAME >/dev/null 2>&1
     if [[ $? -ne 0 ]] ; then
         if [ $USES_SAILFISH_SILICA_QML_IMPORT -eq 1 ]; then
-            validation_error $DESKTOP_NAME "X-Nemo-Application-Type must be silica-qt5 for apps importing Sailfish.Silica in QML"
+            validation_warning $DESKTOP_NAME "X-Nemo-Application-Type should be silica-qt5 for apps importing Sailfish.Silica in QML"
+            validation_info $DESKTOP_NAME "Set X-Nemo-Application-Type to silica-qt5 unless mapplauncherd can't start the application."
+            validation_info $DESKTOP_NAME "See also: https://github.com/nemomobile/mapplauncherd/blob/master/README"
             INFO_MSG_PRINTED=1
         fi
         if [ $USES_SAILFISH_QML_LAUNCHER -eq 1 ]; then

--- a/tests/expected_outputs/testHarbourBadArm.txt
+++ b/tests/expected_outputs/testHarbourBadArm.txt
@@ -114,7 +114,9 @@ Desktop file
 ============
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Missing valid Icon declaration, must be Icon=harbour-bad
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Missing valid Exec declaration, must be Exec=harbour-bad
-[31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type must be silica-qt5 for apps importing Sailfish.Silica in QML
+[33mWARNING[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type should be silica-qt5 for apps importing Sailfish.Silica in QML
+[36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Set X-Nemo-Application-Type to silica-qt5 unless mapplauncherd can't start the application.
+[36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] See also: https://github.com/nemomobile/mapplauncherd/blob/master/README
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type not declared (use silica-qt5 for QML apps)
 [36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Please see our FAQ here: https://harbour.jolla.com/faq#.desktop-Files
 [31mFAILED[0m

--- a/tests/expected_outputs/testHarbourBadArmNoColor.txt
+++ b/tests/expected_outputs/testHarbourBadArmNoColor.txt
@@ -114,7 +114,9 @@ Desktop file
 ============
 ERROR [/usr/share/applications/harbour-bad.desktop] Missing valid Icon declaration, must be Icon=harbour-bad
 ERROR [/usr/share/applications/harbour-bad.desktop] Missing valid Exec declaration, must be Exec=harbour-bad
-ERROR [/usr/share/applications/harbour-bad.desktop] X-Nemo-Application-Type must be silica-qt5 for apps importing Sailfish.Silica in QML
+WARNING [/usr/share/applications/harbour-bad.desktop] X-Nemo-Application-Type should be silica-qt5 for apps importing Sailfish.Silica in QML
+INFO [/usr/share/applications/harbour-bad.desktop] Set X-Nemo-Application-Type to silica-qt5 unless mapplauncherd can't start the application.
+INFO [/usr/share/applications/harbour-bad.desktop] See also: https://github.com/nemomobile/mapplauncherd/blob/master/README
 ERROR [/usr/share/applications/harbour-bad.desktop] X-Nemo-Application-Type not declared (use silica-qt5 for QML apps)
 INFO [/usr/share/applications/harbour-bad.desktop] Please see our FAQ here: https://harbour.jolla.com/faq#.desktop-Files
 FAILED

--- a/tests/expected_outputs/testHarbourBadIntel.txt
+++ b/tests/expected_outputs/testHarbourBadIntel.txt
@@ -115,7 +115,9 @@ Desktop file
 ============
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Missing valid Icon declaration, must be Icon=harbour-bad
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Missing valid Exec declaration, must be Exec=harbour-bad
-[31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type must be silica-qt5 for apps importing Sailfish.Silica in QML
+[33mWARNING[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type should be silica-qt5 for apps importing Sailfish.Silica in QML
+[36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Set X-Nemo-Application-Type to silica-qt5 unless mapplauncherd can't start the application.
+[36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] See also: https://github.com/nemomobile/mapplauncherd/blob/master/README
 [31mERROR[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] X-Nemo-Application-Type not declared (use silica-qt5 for QML apps)
 [36mINFO[0m [[34m/usr/share/applications/harbour-bad.desktop[0m] Please see our FAQ here: https://harbour.jolla.com/faq#.desktop-Files
 [31mFAILED[0m


### PR DESCRIPTION
Currently if an app uses Silica components, it's mandatory to use silica-qt5 booster.

A real life example which uses Go, seems not to be able to use that booster while it has qml files which use Silica components. So we should turn the error into a warning.