### PR TITLE
[conf] allow QtQuick 2.2

### DIFF
--- a/allowed_qmlimports.conf
+++ b/allowed_qmlimports.conf
@@ -16,6 +16,9 @@ QtQuick.Particles 2.1
 QtQuick.Window 2.1
 QtQuick.Layouts 1.1
 
+# Qt Quick 2.2
+QtQuick 2.2
+
 # Additional QML modules
 QtMultimedia 5.0
 QtWebKit 3.0


### PR DESCRIPTION
Sailfish Silica Reference says, that one should import QtQuick 2.2,
also all examples there are using QtQuick 2.2. Fixes JB#32548
and addresses issue #68