### PR TITLE
[conf] Relax application internal qml module naming rules. 

### DIFF
--- a/disallowed_qmlimport_patterns.conf
+++ b/disallowed_qmlimport_patterns.conf
@@ -1,0 +1,13 @@
+^Bluetooth\.
+^Meego\.
+^Mer\.
+^Nemo\.
+^NemoMobile\.
+^Sailfish\.
+^Qt
+^org\.nemomobile\.
+^org\.sailfishos\.
+^com\.jolla\.
+^com\.nokia\.
+^com\.meego\.
+^org\.kde\.bluezqt

--- a/rpmvalidation.conf
+++ b/rpmvalidation.conf
@@ -18,6 +18,7 @@ SRC_DEBUG_NAME="$PROG_PATH/src/debug"
 # Libraries
 #
 ALLOWED_LIBRARIES="allowed_libraries.conf"
+DISALLOWED_QMLIMPORTS="disallowed_qmlimport_patterns.conf"
 ALLOWED_QMLIMPORTS="allowed_qmlimports.conf"
 
 GLIBC_MAIN_VERSION_ARM='2.4'

--- a/rpmvalidation.sh
+++ b/rpmvalidation.sh
@@ -761,11 +761,8 @@ validateqmlfiles() {
                                 validation_error "$QML_FILE" "Import '$QML_IMPORT' is not valid - the path points to an unsupported external path"
                             fi
                         else
-                            # it could be an own provided QML module then there has to be a Modulename/qmldir file under SHARE_NAME
-                            QML_IMPORT_MODUL_NAME=$(echo $QML_IMPORT| $SED -e 's/\s\+/ /g' | $CUT -f1 -d ' ')
-                            NAME_IN_QML_FORM=$(echo $NAME| $SED -e 's/-/\./g')
-                            if [[ "${QML_IMPORT_MODUL_NAME##$NAME_IN_QML_FORM}" != "$QML_IMPORT_MODUL_NAME" ]] ; then
-                                # OK QML module name has the app name as prefix
+                            # allow all except explicitly disallowed modules
+                            if ! (echo $QML_IMPORT | grep -f $SCRIPT_DIR/$DISALLOWED_QMLIMPORTS); then
                                 continue
                             fi
                         fi


### PR DESCRIPTION
Allow all module names that the operating system is not using
(Qt*, Sailfish*, Nemo* etc). These still have to be registered inside
the application, main.cpp or so, not allowing globally installed module
files.

--
Skipped org.freedesktop prefix from the existing modules. Only contains context kit which is explicitly allowed.
