### PR TITLE
libsqlite3.so.0 added into the list of allowed libraries

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -95,6 +95,7 @@ liblzma.so.5
 libxml2.so.2
 libbz2.so.1
 libexpat.so.1
+libsqlite3.so.0
 
 # GLib
 libgio-2.0.so.0


### PR DESCRIPTION
To my understanding, SQLite is used in several core parts of Sailfish. Its an important library in Linux and allows to expand functionality of applications in SFOS. In particular, it allows to use other libraries developed in Linux that use SQLite as a backend for their storage. In my case, adding sqlite3 into the list of allowed libraries allows me to incorporate a new geocoder into offline maps server application that I wrote for SFOS. 