### PR TITLE
[conf] Allow versioned additional qt libraries.

### DIFF
--- a/allowed_libraries.conf
+++ b/allowed_libraries.conf
@@ -81,7 +81,9 @@ libQt5Xml.so.5
 libQt5DBus.so.5
 libQt5WebKit.so.5
 libQt5Sensors.so.5
+libQt5Sensors.so.5(Qt_5)
 libQt5Positioning.so.5
+libQt5Positioning.so.5(Qt_5)
 
 # Various additional libraries that are useful
 libmlite5.so.0


### PR DESCRIPTION
Some libraries that were allowed before (like ```libQt5Positioning.so.5```) are now failing because the version is not allowed, see this [TJC](https://together.jolla.com/question/156435/sdk-version-1701-released-early-access/) answer.

I've added the versions to the allowed libraries, for those I know are failing, but maybe it would be necessary also to allow (Qt_5) version to all other additional Qt5 libraries ?